### PR TITLE
chore: refactor fetcher params (#126)

### DIFF
--- a/apps/test/src/pages/index.tsx
+++ b/apps/test/src/pages/index.tsx
@@ -8,7 +8,11 @@ const Index = () => {
 
   useEffect(() => {
     const deployment = DEPLOYMENTS[provider.network.chainId];
-    const params = { signerOrProvider: provider, deployment };
+    const params = {
+      signerOrProvider: provider,
+      subgraphURI: deployment.subgraphURI,
+      lbWrapperAddress: deployment.lbWrapperAddress,
+    };
     getLeverageBuy({ escrowID: "0", ...params })
       .then((json) => console.log({ json }))
       .catch((e) => console.log(e));

--- a/libs/margin-core/src/lib/fetchers/getCollateralLimits.ts
+++ b/libs/margin-core/src/lib/fetchers/getCollateralLimits.ts
@@ -18,9 +18,9 @@ export interface GetCollateralLimitsResult {
 }
 
 const _getCollateralLimits = async (params: GetCollateralLimitsParams): Promise<GetCollateralLimitsResult> => {
-  const { signerOrProvider, deployment, collectionAddress, tokenID, vaultAddress } = params;
+  const { signerOrProvider, lbWrapperAddress, collectionAddress, tokenID, vaultAddress } = params;
 
-  const lbWrapper = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signerOrProvider);
+  const lbWrapper = LeverageBuyWrapperV1__factory.connect(lbWrapperAddress, signerOrProvider);
   const limits = await lbWrapper.getCollateralLimits(vaultAddress, collectionAddress, tokenID);
 
   return {

--- a/libs/margin-core/src/lib/fetchers/getFlashFee.ts
+++ b/libs/margin-core/src/lib/fetchers/getFlashFee.ts
@@ -8,8 +8,8 @@ export interface GetFlashFeeParams extends FetcherParams {
 }
 
 const _getFlashFee = async (params: GetFlashFeeParams): Promise<BigNumber> => {
-  const { deployment, loanAmount, signerOrProvider } = params;
-  const lbWrapper = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signerOrProvider);
+  const { lbWrapperAddress, loanAmount, signerOrProvider } = params;
+  const lbWrapper = LeverageBuyWrapperV1__factory.connect(lbWrapperAddress, signerOrProvider);
   const [flashLenderAddress, wethAddress] = await Promise.all([lbWrapper.flashLender(), lbWrapper.weth()]);
 
   const flashLender = IERC3156FlashLender__factory.connect(flashLenderAddress, signerOrProvider);

--- a/libs/margin-core/src/lib/fetchers/getReservoirFillCalldata.ts
+++ b/libs/margin-core/src/lib/fetchers/getReservoirFillCalldata.ts
@@ -1,21 +1,21 @@
-import { Deployment } from "../deployments";
 import { withReadableError } from "../errors";
 
 interface GetReservoirFillCalldataProps {
-  deployment: Deployment;
+  lbWrapperAddress: string;
+  reservoirURL: string;
   collectionAddress: string;
   tokenID: string;
   apiKey?: string;
 }
 
 const _getReservoirFillCalldata = async (props: GetReservoirFillCalldataProps): Promise<string> => {
-  const { deployment, collectionAddress, tokenID, apiKey } = props;
+  const { lbWrapperAddress, reservoirURL, collectionAddress, tokenID, apiKey } = props;
   // construct URL
   const params = new URLSearchParams();
-  params.append("taker", deployment.lbWrapperAddress);
+  params.append("taker", lbWrapperAddress);
   params.append("token", `${collectionAddress}:${tokenID}`);
   params.append("skipBalanceCheck", "true");
-  const url = `${deployment.reservoirURL}/execute/buy/v2?${params}`;
+  const url = `${reservoirURL}/execute/buy/v2?${params}`;
   // if api key was passed, add it to the headers
   const headers: Record<string, string> = {};
   if (apiKey) headers["x-api"] = apiKey;

--- a/libs/margin-core/src/lib/fetchers/quoteMultipleERC721.ts
+++ b/libs/margin-core/src/lib/fetchers/quoteMultipleERC721.ts
@@ -19,8 +19,7 @@ export interface QuoteMultipleERC721Result {
 }
 
 const _quoteMultipleERC721 = async (params: QuoteMultipleERC721Params): Promise<QuoteMultipleERC721Result> => {
-  const { signerOrProvider, deployment } = params;
-  const leverageBuyWrapper = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signerOrProvider);
+  const leverageBuyWrapper = LeverageBuyWrapperV1__factory.connect(params.lbWrapperAddress, params.signerOrProvider);
   const quote = await leverageBuyWrapper.quoteMultipleERC721(
     params.purchasePrices,
     params.downPayments,

--- a/libs/margin-core/src/lib/fetchers/quoteRefinance.ts
+++ b/libs/margin-core/src/lib/fetchers/quoteRefinance.ts
@@ -19,8 +19,7 @@ export interface QuoteRefinanceResult {
 }
 
 const _quoteRefinance = async (params: QuoteRefinanceParams): Promise<QuoteRefinanceResult> => {
-  const { signerOrProvider, deployment } = params;
-  const contract = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signerOrProvider);
+  const contract = LeverageBuyWrapperV1__factory.connect(params.lbWrapperAddress, params.signerOrProvider);
   const quote = await contract.quoteRefinance(
     params.balance,
     params.downPayment,

--- a/libs/margin-core/src/lib/fetchers/quoteSingleERC721.ts
+++ b/libs/margin-core/src/lib/fetchers/quoteSingleERC721.ts
@@ -18,14 +18,13 @@ export interface QuoteSingleERC721Result {
 }
 
 const _quoteSingleERC721 = async (params: QuoteSingleERC721Params): Promise<QuoteSingleERC721Result> => {
-  const { signerOrProvider, deployment } = params;
-  const leverageBuyWrapper = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signerOrProvider);
+  const leverageBuyWrapper = LeverageBuyWrapperV1__factory.connect(params.lbWrapperAddress, params.signerOrProvider);
   const quote = await leverageBuyWrapper.quoteSingleERC721(
     params.purchasePrice,
     params.downPayment,
     params.collectionAddress,
     params.tokenID,
-    deployment.lbWrapperAddress,
+    params.lbWrapperAddress,
     params.duration
   );
   return {

--- a/libs/margin-core/src/lib/fetchers/subgraph/getLeverageBuy.ts
+++ b/libs/margin-core/src/lib/fetchers/subgraph/getLeverageBuy.ts
@@ -37,17 +37,18 @@ const getPayload = (id: string) => {
 };
 
 interface GetLeverageBuyParams extends FetcherParams {
+  subgraphURI: string;
   escrowID: string;
 }
 
 export const getLeverageBuy = async (params: GetLeverageBuyParams): Promise<LeverageBuy> => {
-  const { signerOrProvider, deployment, escrowID } = params;
+  const { signerOrProvider, escrowID, lbWrapperAddress, subgraphURI } = params;
 
-  const lbWrapper = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signerOrProvider);
+  const lbWrapper = LeverageBuyWrapperV1__factory.connect(lbWrapperAddress, signerOrProvider);
   const pePlatformAddress = await lbWrapper.purchaseEscrow();
-  const id = `${deployment.lbWrapperAddress}-${pePlatformAddress}-${escrowID}`.toLowerCase();
+  const id = `${lbWrapperAddress}-${pePlatformAddress}-${escrowID}`.toLowerCase();
 
-  const response = await fetch(params.deployment.subgraphURI, {
+  const response = await fetch(subgraphURI, {
     method: "POST",
     body: getPayload(id),
     headers: { "Content-Type": "application/json" },

--- a/libs/margin-core/src/lib/fetchers/subgraph/getLeverageBuyEvents.ts
+++ b/libs/margin-core/src/lib/fetchers/subgraph/getLeverageBuyEvents.ts
@@ -1,4 +1,3 @@
-import { Deployment } from "../../deployments";
 import { RawLeverageBuyEvent, transformRawLeverageBuyEvent } from "./transformers";
 import { LeverageBuyEvent } from "./types";
 
@@ -73,14 +72,14 @@ const getPayload = (variables: GetPayloadVariables) => {
   return JSON.stringify(payload);
 };
 
-export type GetLeverageBuyEventsParams = { deployment: Deployment } & GetPayloadVariables;
+export type GetLeverageBuyEventsParams = { subgraphURI: string } & GetPayloadVariables;
 
 export type GetLeverageBuyEventsResult = LeverageBuyEvent[];
 
 export const getLeverageBuyEvents = async (params: GetLeverageBuyEventsParams): Promise<GetLeverageBuyEventsResult> => {
-  const { deployment, ...variables } = params;
+  const { subgraphURI, ...variables } = params;
 
-  const response = await fetch(deployment.subgraphURI, {
+  const response = await fetch(subgraphURI, {
     method: "POST",
     body: getPayload(variables),
     headers: { "Content-Type": "application/json" },

--- a/libs/margin-core/src/lib/fetchers/subgraph/getLeverageBuys.ts
+++ b/libs/margin-core/src/lib/fetchers/subgraph/getLeverageBuys.ts
@@ -1,4 +1,3 @@
-import { Deployment } from "../../deployments";
 import { RawLeverageBuy, transformRawLeverageBuy } from "./transformers";
 import { LeverageBuy } from "./types";
 
@@ -45,15 +44,12 @@ const getPayload = (variables: GetPayloadVariables) => {
   return JSON.stringify(payload);
 };
 
-export type GetLeverageBuysParams = { deployment: Deployment } & GetPayloadVariables;
+export type GetLeverageBuysParams = { subgraphURI: string } & GetPayloadVariables;
 
 export type GetLeverageBuysResult = LeverageBuy[];
 
 export const getLeverageBuys = async (params: GetLeverageBuysParams): Promise<LeverageBuy[]> => {
-  const {
-    deployment: { subgraphURI },
-    ...variables
-  } = params;
+  const { subgraphURI, ...variables } = params;
 
   const response = await fetch(subgraphURI, {
     method: "POST",

--- a/libs/margin-core/src/lib/fetchers/types.ts
+++ b/libs/margin-core/src/lib/fetchers/types.ts
@@ -1,10 +1,9 @@
 import { Provider } from "@ethersproject/providers";
 import { Signer } from "ethers";
-import { Deployment } from "../deployments";
 
 export type SignerOrProvider = Signer | Provider;
 
 export interface FetcherParams {
   signerOrProvider: SignerOrProvider;
-  deployment: Deployment;
+  lbWrapperAddress: string;
 }

--- a/libs/margin-kit/src/lib/components/BuyWithLeverageModal/state/useBuyWithLeverageTransaction.ts
+++ b/libs/margin-kit/src/lib/components/BuyWithLeverageModal/state/useBuyWithLeverageTransaction.ts
@@ -50,7 +50,7 @@ const useBuyWithLeverageTransaction = (props: UseBuyWithLeverageTransactionProps
 
     /* send transaction based on the number of tokens */
     const sendTransaction = async () => {
-      const fillCallDatas = await Promise.all(tokens.map((t) => getReservoirFillCalldata({ ...t, deployment })));
+      const fillCallDatas = await Promise.all(tokens.map((t) => getReservoirFillCalldata({ ...t, ...deployment })));
 
       if (tokens.length > 1) {
         return buyMultipleERC721WithETH({

--- a/libs/margin-kit/src/lib/lib/hooks/useCollateralLimits.ts
+++ b/libs/margin-kit/src/lib/lib/hooks/useCollateralLimits.ts
@@ -15,7 +15,7 @@ const useCollateralLimits = (params: UseCollateralLimitsParams) => {
   const chainID = useChainID();
 
   const [fetcher, enabled] = useFetcherWithDeployment((deployment) => {
-    return getCollateralLimits({ signerOrProvider: provider, deployment, ...params });
+    return getCollateralLimits({ signerOrProvider: provider, ...deployment, ...params });
   });
 
   return useQuery<GetCollateralLimitsResult, ReadableError>(collateralLimitsQueryKeys.token(chainID, params), fetcher, {

--- a/libs/margin-kit/src/lib/lib/hooks/useFlashFee.ts
+++ b/libs/margin-kit/src/lib/lib/hooks/useFlashFee.ts
@@ -11,7 +11,7 @@ const useFlashFee = (loanAmount: BigNumberish) => {
   const [fetcher, enabled] = useFetcherWithDeployment((deployment) => {
     return getFlashFee({
       signerOrProvider: provider,
-      deployment,
+      ...deployment,
       loanAmount,
     });
   });

--- a/libs/margin-kit/src/lib/lib/hooks/useLeverageBuys.ts
+++ b/libs/margin-kit/src/lib/lib/hooks/useLeverageBuys.ts
@@ -6,7 +6,7 @@ export const useLeverageBuys = () => {
   const { address: owner = "" } = useAccount();
 
   const [fetcher, enabled] = useFetcherWithDeployment((deployment) => {
-    return getLeverageBuys({ deployment, owner, skip: 0, first: 1000 });
+    return getLeverageBuys({ ...deployment, owner, skip: 0, first: 1000 });
   });
 
   return useQuery<LeverageBuy[], ReadableError>(leverageBuysQueryKeys.owner(owner), fetcher, {

--- a/libs/margin-kit/src/lib/lib/hooks/useQuoteMultipleERC721.ts
+++ b/libs/margin-kit/src/lib/lib/hooks/useQuoteMultipleERC721.ts
@@ -33,7 +33,7 @@ const useQuoteMultipleERC721 = (props: UseQuoteMultipleERC721Props) => {
 
     return quoteMultipleERC721({
       signerOrProvider: provider,
-      deployment,
+      lbWrapperAddress: deployment.lbWrapperAddress,
       purchasePrices,
       downPayments,
       collectionAddresses,

--- a/libs/margin-kit/src/lib/lib/hooks/useQuoteRefinance.ts
+++ b/libs/margin-kit/src/lib/lib/hooks/useQuoteRefinance.ts
@@ -7,13 +7,13 @@ import {
 import { useProvider, useQuery } from "wagmi";
 import { useFetcherWithDeployment } from "./useFetcherWithDeployment";
 
-export type UseQuoteRefinanceParams = Omit<QuoteRefinanceParams, "signerOrProvider" | "deployment">;
+export type UseQuoteRefinanceParams = Omit<QuoteRefinanceParams, "signerOrProvider" | "lbWrapperAddress">;
 
 export const useQuoteRefinance = (params: UseQuoteRefinanceParams) => {
   const provider = useProvider();
 
   const [fetcher, enabled] = useFetcherWithDeployment((deployment) => {
-    return quoteRefinance({ ...params, signerOrProvider: provider, deployment });
+    return quoteRefinance({ ...params, signerOrProvider: provider, lbWrapperAddress: deployment.lbWrapperAddress });
   });
 
   return useQuery<QuoteRefinanceResult, ReadableError>(

--- a/libs/margin-kit/src/lib/lib/hooks/useVaultsLimits.ts
+++ b/libs/margin-kit/src/lib/lib/hooks/useVaultsLimits.ts
@@ -18,8 +18,8 @@ export const useVaultsLimits = (params: UseVaultsLimitsParams) => {
       deployment.vaults.map(async (vaultAddress) => {
         const limit = await getCollateralLimits({
           ...params,
+          ...deployment,
           vaultAddress,
-          deployment,
           signerOrProvider: provider,
         });
         return { ...limit, vaultAddress };


### PR DESCRIPTION
refactored fetchers to take the necessary params only, instead of the whole `Deployment` object