### PR TITLE
chore: refactor transaction params (#126)

### DIFF
--- a/apps/test/src/pages/trades.tsx
+++ b/apps/test/src/pages/trades.tsx
@@ -60,7 +60,7 @@ const LBRow = (props: LBRowProps) => {
     if (!deployment) throw new Error("cancelListing was called without a deployment");
     cancelListing({
       signer,
-      deployment,
+      lbWrapperAddress: deployment.lbWrapperAddress,
       escrowID: leverageBuy.escrowID,
       marketplace: Marketplace.Seaport,
       listingData: leverageBuy.listingData.raw,

--- a/libs/margin-core/src/lib/transactions/buyMultipleERC721WithETH.ts
+++ b/libs/margin-core/src/lib/transactions/buyMultipleERC721WithETH.ts
@@ -13,8 +13,7 @@ export interface BuyMultipleERC721WithETHParams extends TransactionParams {
 }
 
 const _buyMultipleERC721WithETH = (params: BuyMultipleERC721WithETHParams): Promise<ContractTransaction> => {
-  const { signer, deployment } = params;
-  const contract = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signer);
+  const contract = LeverageBuyWrapperV1__factory.connect(params.lbWrapperAddress, params.signer);
   const totalDownPayment = params.downPayments.reduce(
     (total, downPayment) => BigNumber.from(total).add(downPayment),
     0

--- a/libs/margin-core/src/lib/transactions/buySingleERC721WithETH.ts
+++ b/libs/margin-core/src/lib/transactions/buySingleERC721WithETH.ts
@@ -13,8 +13,7 @@ export interface BuySingleERC721WithETHParams extends TransactionParams {
 }
 
 const _buySingleERC721WithETH = (params: BuySingleERC721WithETHParams): Promise<ContractTransaction> => {
-  const { signer, deployment } = params;
-  const contract = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signer);
+  const contract = LeverageBuyWrapperV1__factory.connect(params.lbWrapperAddress, params.signer);
   return contract.buySingleERC721WithETH(
     params.purchasePrice,
     params.fillCallData,

--- a/libs/margin-core/src/lib/transactions/cancelListing.ts
+++ b/libs/margin-core/src/lib/transactions/cancelListing.ts
@@ -13,11 +13,9 @@ type CancelListingParams = TransactionParams & {
 };
 
 const _cancelListing = async (params: CancelListingParams) => {
-  const { signer, deployment } = params;
-
-  const lbWrapper = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signer);
+  const lbWrapper = LeverageBuyWrapperV1__factory.connect(params.lbWrapperAddress, params.signer);
   const pePlatformAddress = await lbWrapper.purchaseEscrow();
-  const pePlatform = PurchaseEscrowPlatform__factory.connect(pePlatformAddress, signer);
+  const pePlatform = PurchaseEscrowPlatform__factory.connect(pePlatformAddress, params.signer);
   return pePlatform.cancelListing(params.escrowID, params.marketplace, params.listingData);
 };
 

--- a/libs/margin-core/src/lib/transactions/createListing.ts
+++ b/libs/margin-core/src/lib/transactions/createListing.ts
@@ -20,11 +20,9 @@ type CreateListingParams = TransactionParams & {
 };
 
 const _createListing = async (params: CreateListingParams) => {
-  const { deployment, signer } = params;
-
-  const lbWrapper = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signer);
+  const lbWrapper = LeverageBuyWrapperV1__factory.connect(params.lbWrapperAddress, params.signer);
   const pePlatformAddress = await lbWrapper.purchaseEscrow();
-  const pePlatform = PurchaseEscrowPlatform__factory.connect(pePlatformAddress, signer);
+  const pePlatform = PurchaseEscrowPlatform__factory.connect(pePlatformAddress, params.signer);
   return pePlatform.createListing(
     params.escrowID,
     params.marketplace,

--- a/libs/margin-core/src/lib/transactions/refinanceETH.ts
+++ b/libs/margin-core/src/lib/transactions/refinanceETH.ts
@@ -15,11 +15,9 @@ export type RefinanceETHParams = TransactionParams & {
 };
 
 const _refinanceETH = async (params: RefinanceETHParams) => {
-  const { deployment, signer } = params;
-
-  const lbWrapper = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signer);
+  const lbWrapper = LeverageBuyWrapperV1__factory.connect(params.lbWrapperAddress, params.signer);
   const pePlatformAddress = await lbWrapper.purchaseEscrow();
-  const pePlatform = PurchaseEscrowPlatform__factory.connect(pePlatformAddress, signer);
+  const pePlatform = PurchaseEscrowPlatform__factory.connect(pePlatformAddress, params.signer);
 
   const calldata = ethers.utils.defaultAbiCoder.encode(
     ["address", "uint64", "int256", "uint256"],
@@ -28,7 +26,7 @@ const _refinanceETH = async (params: RefinanceETHParams) => {
 
   const payable = BigNumber.from(params.downPayment).gt(0);
 
-  return pePlatform.transferAndCall(params.escrowID, deployment.lbWrapperAddress, calldata, {
+  return pePlatform.transferAndCall(params.escrowID, params.lbWrapperAddress, calldata, {
     value: payable ? params.downPayment : undefined,
   });
 };

--- a/libs/margin-core/src/lib/transactions/repayETH.ts
+++ b/libs/margin-core/src/lib/transactions/repayETH.ts
@@ -12,12 +12,9 @@ export interface RepayETHParams extends TransactionParams {
 }
 
 const _repayETH = async (params: RepayETHParams): Promise<ContractTransaction> => {
-  const { deployment, signer } = params;
-
-  const lbWrapper = LeverageBuyWrapperV1__factory.connect(deployment.lbWrapperAddress, signer);
+  const lbWrapper = LeverageBuyWrapperV1__factory.connect(params.lbWrapperAddress, params.signer);
   const pePlatformAddress = await lbWrapper.purchaseEscrow();
-
-  const pePlatform = PurchaseEscrowPlatform__factory.connect(pePlatformAddress, signer);
+  const pePlatform = PurchaseEscrowPlatform__factory.connect(pePlatformAddress, params.signer);
   return pePlatform.repayETH(params.escrowID, { value: params.repayment });
 };
 

--- a/libs/margin-core/src/lib/transactions/types.ts
+++ b/libs/margin-core/src/lib/transactions/types.ts
@@ -1,7 +1,6 @@
 import { Signer } from "ethers";
-import { Deployment } from "../deployments";
 
 export interface TransactionParams {
   signer: Signer;
-  deployment: Deployment;
+  lbWrapperAddress: string;
 }

--- a/libs/margin-kit/src/lib/components/BuyWithLeverageModal/state/useBuyWithLeverageTransaction.ts
+++ b/libs/margin-kit/src/lib/components/BuyWithLeverageModal/state/useBuyWithLeverageTransaction.ts
@@ -47,6 +47,7 @@ const useBuyWithLeverageTransaction = (props: UseBuyWithLeverageTransactionProps
     const downPayments = formState.downPayments.map((downPayment) => downPayment.toString());
     const maxRepayments = formState.quote.repayments.map((repayment) => repayment.mul(105).div(100).toString());
     const vaultAddress = formState.activeVaultLimits.vaultAddress;
+    const { lbWrapperAddress } = deployment;
 
     /* send transaction based on the number of tokens */
     const sendTransaction = async () => {
@@ -55,7 +56,7 @@ const useBuyWithLeverageTransaction = (props: UseBuyWithLeverageTransactionProps
       if (tokens.length > 1) {
         return buyMultipleERC721WithETH({
           signer,
-          deployment,
+          lbWrapperAddress,
           purchasePrices,
           downPayments,
           maxRepayments,
@@ -66,7 +67,7 @@ const useBuyWithLeverageTransaction = (props: UseBuyWithLeverageTransactionProps
       } else {
         return buySingleERC721WithETH({
           signer,
-          deployment,
+          lbWrapperAddress,
           purchasePrice: purchasePrices[0],
           downPayment: downPayments[0],
           maxRepayment: maxRepayments[0],

--- a/libs/margin-kit/src/lib/components/ListForSaleModal/state/useListForSaleTransaction.ts
+++ b/libs/margin-kit/src/lib/components/ListForSaleModal/state/useListForSaleTransaction.ts
@@ -62,12 +62,13 @@ export const useListForSaleTransaction = (params: UseListForSaleTransactionParam
     const endTimestamp = startTimestamp + 7 * 86400;
     const salt = BigNumber.from(utils.randomBytes(32));
     const listingPrice = toUnits(formState.listingPriceNum).toString();
+    const { lbWrapperAddress } = deployment;
 
     let tx: ContractTransaction;
     try {
       tx = await createListing({
-        deployment,
         signer,
+        lbWrapperAddress,
         escrowID,
         marketplace: Marketplace.Seaport,
         feeBasisPoints: fees.opensea.bps,

--- a/libs/margin-kit/src/lib/components/RefinanceModal/state/useRefinanceTransaction.ts
+++ b/libs/margin-kit/src/lib/components/RefinanceModal/state/useRefinanceTransaction.ts
@@ -51,7 +51,7 @@ const useRefinanceTransaction = (params: UseRefinanceTransactionParams): UseRefi
     try {
       tx = await refinanceETH({
         signer,
-        deployment,
+        lbWrapperAddress: deployment.lbWrapperAddress,
         escrowID,
         duration: daysToSeconds(formState.duration),
         downPayment: formState.downPayment,


### PR DESCRIPTION
refactored transactions to take the necessary params only, instead of the whole `Deployment` object