### PR TITLE
chore: make `activeLimits` a derived state (#126)

### DIFF
--- a/libs/margin-kit/src/lib/components/BuyWithLeverageModal/ModalContent/ModalForm.tsx
+++ b/libs/margin-kit/src/lib/components/BuyWithLeverageModal/ModalContent/ModalForm.tsx
@@ -29,8 +29,8 @@ const ModalForm = () => {
         setDebtFactor={actions.setDebtFactor}
       />
       <DurationSlider
-        minDuration={daysFromSeconds(formState.activeVaultLimits.minDuration, "up")}
-        maxDuration={daysFromSeconds(formState.activeVaultLimits.maxDuration)}
+        minDuration={daysFromSeconds(formState.activeLimits.minDuration, "up")}
+        maxDuration={daysFromSeconds(formState.activeLimits.maxDuration)}
         duration={formState.duration}
         setDuration={actions.setDuration}
       />
@@ -38,7 +38,7 @@ const ModalForm = () => {
       <LeverageDropdown
         purchasePrice={purchasePrice}
         debtAmount={formState.debtAmount}
-        limits={formState.activeVaultLimits}
+        limits={formState.activeLimits}
         tokenCount={tokens.length}
       />
       <FloorBreakeven

--- a/libs/margin-kit/src/lib/components/BuyWithLeverageModal/state/useBuyWithLeverageTransaction.ts
+++ b/libs/margin-kit/src/lib/components/BuyWithLeverageModal/state/useBuyWithLeverageTransaction.ts
@@ -46,7 +46,7 @@ const useBuyWithLeverageTransaction = (props: UseBuyWithLeverageTransactionProps
     const purchasePrices = tokens.map((token) => toUnits(token.tokenPrice).toString());
     const downPayments = formState.downPayments.map((downPayment) => downPayment.toString());
     const maxRepayments = formState.quote.repayments.map((repayment) => repayment.mul(105).div(100).toString());
-    const vaultAddress = formState.activeVaultLimits.vaultAddress;
+    const { vaultAddress } = formState.activeLimits;
     const { lbWrapperAddress } = deployment;
 
     /* send transaction based on the number of tokens */


### PR DESCRIPTION
`activeLimits` is just derived from `limits` and `debtAmount`, so it's enough to calculate it in a `useMemo` instead of storing it using `useState`.