### PR TITLE
feat(core): add support for short duration vaults on mainnet

### DIFF
--- a/libs/margin-core/package.json
+++ b/libs/margin-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metastreet-labs/margin-core",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,

--- a/libs/margin-core/src/lib/deployments.ts
+++ b/libs/margin-core/src/lib/deployments.ts
@@ -14,7 +14,11 @@ export interface Deployment {
 
 export const defaultDeployments: Record<number, Deployment> = {
   1: {
-    vaults: ["0x7770cd73e035c37bdf8875eee81577c63202ab8d"],
+    vaults: [
+      "0x7770cd73e035c37bdf8875eee81577c63202ab8d",
+      "0xf538ca7b3d5fb67003173f5827cf56d0dcdb08dd",
+      "0xf380f3ba506498d31310141713e31ffd264b3da2",
+    ],
     lbWrapperAddress: "0x558aD8278B6D127dc8F58e02Ee578Df20ec98406",
     multicallContractAddress: "0xcA11bde05977b3631167028862bE2a173976CA11",
     subgraphURI:

--- a/libs/margin-kit/package.json
+++ b/libs/margin-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metastreet-labs/margin-kit",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "license": "MIT",
   "peerDependencies": {
     "react": "^16 || ^17 || ^18",


### PR DESCRIPTION
@aouahib could you review this and maybe try to test it a bit too? (maybe ask David to try to buy with leverage for a short duration supported asset) 
If you're reasonably certain using 3 vaults will work on mainnet then I think this PR can be merged confidently.

Corresponding PR on the Marketplace: https://app.graphite.dev/github/pr/metastreet-labs/metastreet-new-marketplace/96/feat-add-sorting-to-SupportedCollectionsDropdown-and-Table?panel=stack